### PR TITLE
Remove useless logs

### DIFF
--- a/lib/ex_libnice.ex
+++ b/lib/ex_libnice.ex
@@ -325,7 +325,6 @@ defmodule ExLibnice do
       ) do
     case Unifex.CNode.call(cnode, :send_payload, [stream_id, component_id, payload]) do
       :ok ->
-        Logger.debug("Sent payload: #{inspect(byte_size(payload))} bytes")
         {:reply, :ok, state}
 
       {:error, cause} ->
@@ -397,7 +396,6 @@ defmodule ExLibnice do
         {:ice_payload, _stream_id, _component_id, _payload} = msg,
         %State{parent: parent} = state
       ) do
-    Logger.debug("#{inspect(msg)}")
     send(parent, msg)
     {:noreply, state}
   end


### PR DESCRIPTION
Logging about successful sending or receiving messages is quite useless and makes console output unreadable. 

We could think about logging them e.g every 10 seconds something google chrome does:

```
[13486:18:1207/121436.751071:ERROR:srtp_transport.cc(223)] Failed to unprotect RTP packet: size=33, seqnum=24374, SSRC=3766692804, previous failure count: 100
```

I mean `previous failure count: 100`

This looks pretty cool but it's not important at this moment.